### PR TITLE
Update API validationValue docs to show the real default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ ReactiveForms.createElement({
     // it now takes and returns just a value, not an object.
     console.log('Specifying my own validation value!');
     value = $(el).val();
-    return clean(value, {removeEmptyStrings: false});
+    return clean(value);
   },
   reset: function (el) {
     $(el).val('');


### PR DESCRIPTION
Fixes the current API docs for `createElement` that show an incorrect default value for the `validationValue` method.

The current API docs for `createElement` show an incorrect default value for the `validationValue` method. This leads to confusion because if you copy/paste the documentations default method, you get a different result in certain circumstances vs just not using a `validationValue` method at all.